### PR TITLE
Remove the dependency of the launcher

### DIFF
--- a/hook/fix.cpp
+++ b/hook/fix.cpp
@@ -1,0 +1,100 @@
+#include <windows.h>
+#include <iostream>
+#include <detours.h>
+
+#pragma comment(lib, "detours.lib")
+#pragma comment(lib, "ws2_32.lib")
+
+#define MASTERLIST_HOST_DEFAULT "monitor.sacnr.com"
+#define MASTERLIST_PATH_DEFAULT "/list/masterlist.txt"
+
+int (WINAPI *pSend)(SOCKET s, const char* buf, int len, int flags) = send;
+int WINAPI HOOK_send(SOCKET s, const char* buf, int len, int flags);
+struct hostent* FAR(WINAPI *pgethostbyname)(const char *cp) = gethostbyname;
+struct hostent* FAR WINAPI HOOK_gethostbyname(const char *cp);
+
+char g_szHost[128];
+char g_szHTTPHeaders[256 + 200];
+int g_iHTTPHeadersLen;
+
+struct hostent* FAR WINAPI HOOK_gethostbyname(const char *cp)
+{
+	int iCurTab = *(int*)(0x4EE6E8); // current tab (fav/internet/hosted)
+	if (!strcmp(cp, "lists.sa-mp.com") && iCurTab == 1)
+	{
+		return pgethostbyname(g_szHost);
+	}
+	
+	return pgethostbyname(cp);
+}
+
+int WINAPI HOOK_send(SOCKET s, const char* buf, int len, int flags)
+{
+	if (strstr(buf, "GET /0.3.7/servers") != NULL)
+		return pSend(s, g_szHTTPHeaders, g_iHTTPHeadersLen, flags);
+
+	return pSend(s, buf, len, flags);
+}
+
+void LoadConfig()
+{
+	FILE *fileConfig;
+	bool bConfigWritten = false;
+	char szPath[128];
+
+	if (fopen_s(&fileConfig, "masterlist_fix.cfg", "r") == 0)
+	{
+		if (fgets(g_szHost, sizeof(g_szHost), fileConfig) != NULL && fgets(szPath, sizeof(szPath), fileConfig) != NULL)
+		{
+			g_szHost[strcspn(g_szHost, "\r\n")] = 0;
+			szPath[strcspn(szPath, "\r\n")] = 0;
+
+			bConfigWritten = true;
+		}
+		fclose(fileConfig);
+	}
+
+	if (!bConfigWritten)
+	{
+		strcpy_s(g_szHost, sizeof(g_szHost), MASTERLIST_HOST_DEFAULT);
+		strcpy_s(szPath, sizeof(szPath), MASTERLIST_PATH_DEFAULT);
+	}
+
+	sprintf_s(g_szHTTPHeaders, sizeof(g_szHTTPHeaders), "\
+GET %s HTTP/1.1\r\n\
+Content-Type: text/html\r\n\
+Host: %s\r\n\
+Accept: text/html, */*\r\n\
+User-Agent: Mozilla/3.0 (compatible; SA:MP v0.3.7)\r\n\r\n", szPath, g_szHost);
+
+	g_iHTTPHeadersLen = strlen(g_szHTTPHeaders);
+}
+
+void InitializeFix()
+{
+	LoadConfig();
+
+	DetourTransactionBegin();
+	DetourUpdateThread(GetCurrentThread());
+	DetourAttach(&(PVOID&)pSend, HOOK_send);
+	DetourTransactionCommit();
+
+	DetourTransactionBegin();
+	DetourUpdateThread(GetCurrentThread());
+	DetourAttach(&(PVOID&)pgethostbyname, HOOK_gethostbyname);
+	DetourTransactionCommit();
+}
+
+void GetRidOfMe()
+{
+	// we'll never.
+	DetourTransactionBegin();
+	DetourUpdateThread(GetCurrentThread());
+	DetourDetach(&(PVOID&)pSend, HOOK_send);
+	DetourTransactionCommit();
+
+	DetourTransactionBegin();
+	DetourUpdateThread(GetCurrentThread());
+	DetourDetach(&(PVOID&)pgethostbyname, HOOK_gethostbyname);
+	DetourTransactionCommit();
+}

--- a/hook/main.cpp
+++ b/hook/main.cpp
@@ -1,0 +1,143 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#pragma comment(lib, "ws2_32.lib")
+#include <Shlobj.h>
+#include <iostream>
+
+void InitializeFix();
+void GetRidOfMe();
+
+#define WRAPPER_GENFUNC(name) \
+	FARPROC orig_##name; \
+	__declspec(naked) void _##name() \
+	{ \
+		__asm jmp[orig_##name] \
+	}
+
+WRAPPER_GENFUNC(GetFileVersionInfoA)
+WRAPPER_GENFUNC(GetFileVersionInfoByHandle)
+WRAPPER_GENFUNC(GetFileVersionInfoExW)
+WRAPPER_GENFUNC(GetFileVersionInfoSizeA)
+WRAPPER_GENFUNC(GetFileVersionInfoSizeExW)
+WRAPPER_GENFUNC(GetFileVersionInfoSizeW)
+WRAPPER_GENFUNC(GetFileVersionInfoW)
+WRAPPER_GENFUNC(VerFindFileA)
+WRAPPER_GENFUNC(VerFindFileW)
+WRAPPER_GENFUNC(VerInstallFileA)
+WRAPPER_GENFUNC(VerInstallFileW)
+WRAPPER_GENFUNC(VerLanguageNameA)
+WRAPPER_GENFUNC(VerLanguageNameW)
+WRAPPER_GENFUNC(VerQueryValueA)
+WRAPPER_GENFUNC(VerQueryValueW)
+
+bool InitializeWrapper()
+{
+	char szDLLPath[MAX_PATH];
+
+	if (SUCCEEDED(SHGetFolderPath(NULL,
+		CSIDL_SYSTEM,
+		NULL,
+		0,
+		szDLLPath)))
+	{
+		strcat_s(szDLLPath, MAX_PATH, "\\version.dll");
+
+		HMODULE hModVersion = LoadLibrary(szDLLPath);
+#define WRAPPER_FUNC(name) orig_##name = GetProcAddress(hModVersion, ###name);
+		WRAPPER_FUNC(GetFileVersionInfoA);
+		WRAPPER_FUNC(GetFileVersionInfoByHandle);
+		WRAPPER_FUNC(GetFileVersionInfoExW);
+		WRAPPER_FUNC(GetFileVersionInfoSizeA);
+		WRAPPER_FUNC(GetFileVersionInfoSizeExW);
+		WRAPPER_FUNC(GetFileVersionInfoSizeW);
+		WRAPPER_FUNC(GetFileVersionInfoW);
+		WRAPPER_FUNC(VerFindFileA);
+		WRAPPER_FUNC(VerFindFileW);
+		WRAPPER_FUNC(VerInstallFileA);
+		WRAPPER_FUNC(VerInstallFileW);
+		WRAPPER_FUNC(VerLanguageNameA);
+		WRAPPER_FUNC(VerLanguageNameW);
+		WRAPPER_FUNC(VerQueryValueA);
+		WRAPPER_FUNC(VerQueryValueW);
+
+		return true;
+	}
+	else
+	{
+		MessageBox(NULL, "Failed to get your origin dll.\nPlease report this issue on github,\nand remove version.dll from your GTA:SA Folder until the problem is solved.", "Whoopsie", MB_OK);
+	}
+
+	return false;
+}
+
+BOOL WINAPI DllMain(HINSTANCE hInst, DWORD dwReason, LPVOID)
+{
+	if (dwReason == DLL_PROCESS_ATTACH)
+	{	
+		if (InitializeWrapper())
+		{
+			InitializeFix();
+		}
+		else
+		{
+			exit(0);
+		}
+	}
+	else if (dwReason == DLL_PROCESS_DETACH)
+	{
+		GetRidOfMe();
+	}
+	return true;
+}
+
+/*
+this is old code -> would be a "cleaner" way but damn these delphi "AnsiStrings"
+
+#include <string>
+char buf[128];
+DWORD dwBack = 0x48C7BC;
+
+char *str;
+
+__declspec(naked) void Get(void)
+{
+__asm mov     edx, str //; System::AnsiStrin
+__asm jmp	  [dwBack]
+}
+
+
+#define X86_JMP 0xE9
+
+void Patch(DWORD addr, void* data, size_t size)
+{
+Protect protect(addr, size);
+memcpy(reinterpret_cast<void*>(addr), data, size);
+}
+
+void RedirectInstr(DWORD addr, BYTE instr, void * func)
+{
+DWORD rel_addr = reinterpret_cast<DWORD>(func) - (addr + 5);
+Patch(addr, &instr, 1);
+Patch(addr + 1, &rel_addr, 4);
+}
+
+void ThreadEnter()
+{
+while (true)
+{
+str = new char[64];
+strcat_s(str, 64, "bitq.eu");
+
+DWORD dwBase = reinterpret_cast<DWORD>(GetModuleHandle(NULL));
+dwBack = dwBase + (0x4E6D57 - 0x400000);
+dwBase += (0x4E6D52 - 0x400000);
+
+
+//if (*(BYTE*)(dwBase) == 0xFF)
+{
+RedirectInstr(dwBase, X86_JMP, Get);
+break;
+}
+}
+}
+*/

--- a/hook/mod.def
+++ b/hook/mod.def
@@ -1,0 +1,18 @@
+LIBRARY version.dll
+
+EXPORTS
+	GetFileVersionInfoA        = _GetFileVersionInfoA @1
+	GetFileVersionInfoByHandle = _GetFileVersionInfoByHandle @2
+	GetFileVersionInfoExW      = _GetFileVersionInfoExW @3
+	GetFileVersionInfoSizeA    = _GetFileVersionInfoSizeA @4  
+	GetFileVersionInfoSizeExW  = _GetFileVersionInfoSizeExW @5
+	GetFileVersionInfoSizeW    = _GetFileVersionInfoSizeW @6
+	GetFileVersionInfoW        = _GetFileVersionInfoW @7
+	VerFindFileA               = _VerFindFileA @8    
+	VerFindFileW               = _VerFindFileW @9           
+	VerInstallFileA            = _VerInstallFileA @10           
+	VerInstallFileW            = _VerInstallFileW @11       
+	VerLanguageNameA           = _VerLanguageNameA @12       
+	VerLanguageNameW           = _VerLanguageNameW @13      
+	VerQueryValueA             = _VerQueryValueA @14      
+	VerQueryValueW             = _VerQueryValueW @15   


### PR DESCRIPTION
.. by proxying a dll used by samp.
As you're using VS2010 and I don't got a proper VS2010 configuration I
didn't include the project files but you only need to add the "mod.def"
to the Linker- > Input -> Module Definition File property.
And add fix.cpp and main.cpp to the solution. Or just change it all
together.

This will allow you to just drop the version.dll in the same folder as the samp.exe and it should work.
