### PR TITLE
Server switched back to sa-mp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,7 @@ Fixes the infamous SA-MP internet tab bug.
 ## How does it work?
 Simple! 
 
-This fix injects a DLL into SA-MP client which redirects all the requests outgoing to SA-MP Masterlist (hosted list is not affected) to the server specified in `masterlist_fix.cfg` (default: [SACNR Monitor](http://monitor.sacnr.com/))
-
-Why SACNR? Because they have implemented an API which allows adding of new servers to their Monitor by simple running a filterscript. Details [here](http://monitor.sacnr.com/api.html). 
-
-
-## My server still is not appearing on the internet tab.
-Most probably your server is not registered on the [SACNR Monitor](http://monitor.sacnr.com/). 
-
-You can register your server by following these [steps](http://monitor.sacnr.com/api.html). In the next hours the server should appear on internet tab.
+This fix injects a DLL into SA-MP client which redirects all the requests outgoing to SA-MP Masterlist (hosted list is not affected) to the server specified in `masterlist_fix.cfg`
 
 
 ## Contributors:

--- a/sa-mp_masterlist_fix/fix.cpp
+++ b/sa-mp_masterlist_fix/fix.cpp
@@ -5,8 +5,8 @@
 #pragma comment(lib, "detours.lib")
 #pragma comment(lib, "ws2_32.lib")
 
-#define MASTERLIST_HOST_DEFAULT "monitor.sacnr.com"
-#define MASTERLIST_PATH_DEFAULT "/list/masterlist.txt"
+#define MASTERLIST_HOST_DEFAULT "server.sa-mp.com"
+#define MASTERLIST_PATH_DEFAULT "/0.3.7/servers"
 
 int (WINAPI *pSend)(SOCKET s, const char* buf, int len, int flags) = send;
 int WINAPI HOOK_send(SOCKET s, const char* buf, int len, int flags);


### PR DESCRIPTION
SACNR Monitor was shut down, but `server.sa-mp.com` still returns proper internet servers list.
![image](https://user-images.githubusercontent.com/49686333/145730988-f430a446-53a3-4719-9b9a-995f80ee6dd1.png)
