### PR TITLE
[low importance] Get Masterlist through Cloudflare

### DIFF
--- a/sa-mp_masterlist_fix/sa-mp_masterlist_fix.json
+++ b/sa-mp_masterlist_fix/sa-mp_masterlist_fix.json
@@ -5,7 +5,7 @@
     },
     "endpoints": {
         "internet": {
-            "url": "http://gateway.markski.ar:42069/api/GetMasterlist?version=$(version)"
+            "url": "http://sam.markski.ar/api/GetMasterlist?version=$(version)"
         },
         "hosted": {
             "url": "http://lists.sa-mp.com/$(version)/hosted"


### PR DESCRIPTION
This changes the SAMonitor listing to be got through a cloudflare-protected URL. It has advantages (namely more availability in case of ddos or downtime).

Sorry if this is an annoyance, I had a lack of foresight not making this URL the default initially.

This is not urgent and I'll continue to support gateway.markski.ar:42069 for the foreseeable future, but this should ideally be made the default when you got time.

Cheers